### PR TITLE
Unify portfolio page footers

### DIFF
--- a/portfolio/heather.html
+++ b/portfolio/heather.html
@@ -282,56 +282,51 @@
   </main>
 
   <!-- Footer -->
-  <footer class="site-footer">
-    <div class="footer-nav">
-      <div class="footer-col">
-        <h4>Artists</h4>
-        <ul>
-          <li><a href="micah.html">Micah</a></li>
-          <li><a href="pagan.html">Pagan</a></li>
-          <li><a href="jimmy.html">Jimmy</a></li>
-          <li><a href="kason.html">Kason</a></li>
-          <li><a href="sarah.html">Sarah</a></li>
-          <li><a href="heather.html">Heather</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Services</h4>
-        <ul>
-          <li><a href="../index.html#services">Tattoos</a></li>
-          <li><a href="../index.html#services">Piercing</a></li>
-          <li><a href="../index.html#faq">Aftercare</a></li>
-          <li><a href="../index.html#book">Booking</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Info</h4>
-        <ul>
-          <li><a href="../index.html#about">About</a></li>
-          <li><a href="../index.html#faq">FAQ</a></li>
-          <li><a href="../index.html#studio">Studio</a></li>
-          <li><a href="../index.html#contact">Contact</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Explore</h4>
-        <ul>
-          <li><a href="../index.html#about">About</a></li>
-          <li><a href="../studio.html">Studio News</a></li>
-        </ul>
-      </div>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+        <div class="footer-content">
+            <div class="footer-brand">
+                <div class="footer-logo">
+                    <img src="../images/logo.jpg" alt="Valhalla Tattoo" class="footer-logo-img">
+                    <span class="footer-logo-text">VALHALLA TATTOO</span>
+                </div>
+                <p class="footer-tagline">Crafting Legends in Ink</p>
+            </div>
+            <div class="footer-info">
+                <h4>Contact Info</h4>
+                <address>
+                    <p>404 Mclemore Ave. Suite 4<br>Spring Hill, TN 37174</p>
+                    <p><a href="tel:931-451-5313">931-451-5313</a></p>
+                </address>
+            </div>
+            <div class="footer-hours">
+                <h4>Studio Hours</h4>
+                <p>Tuesday - Saturday<br>12:00 PM - 8:00 PM</p>
+                <p>Sunday & Monday<br>Closed</p>
+            </div>
+            <div class="footer-social">
+                <h4>Follow Us</h4>
+                <div class="footer-social-links">
+                    <a href="https://www.instagram.com/valhallatattoollc/" class="footer-social-link" aria-label="Follow Valhalla Tattoo on Instagram">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
+                        </svg>
+                    </a>
+                    <a href="https://www.facebook.com/Valhallatattoollc" class="footer-social-link" aria-label="Follow Valhalla Tattoo on Facebook">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2024 Valhalla Tattoo. All rights reserved.</p>
+            <p>Crafted with ⚡ in Spring Hill, TN</p>
+        </div>
     </div>
-    <div class="footer-bottom">
-      <a href="../index.html#book" class="btn-cta">Book</a>
-      <div class="social-icons">
-        <a href="https://www.instagram.com/thevalhallatattoo/" aria-label="Instagram"><span
-            class="icon instagram-icon"></span></a>
-        <a href="https://www.facebook.com/Valhallatattoollc" aria-label="Facebook"><span class="icon facebook-icon"></span></a>
-        <a href="https://twitter.com/valhallatattoo" aria-label="Twitter"><span class="icon twitter-icon"></span></a>
-      </div>
-      <p>All rights reserved © 2025 Valhalla Tattoo</p>
-    </div>
-  </footer>
+</footer>
+
 
   <script type="module" src="../js/main.js"></script>
   <script type="module" src="../components/portfolio/artist-bio.js"></script>

--- a/portfolio/jimmy.html
+++ b/portfolio/jimmy.html
@@ -338,54 +338,51 @@
   </main>
 
   <!-- Footer -->
-  <footer class="site-footer">
-    <div class="footer-nav">
-      <div class="footer-col">
-        <h4>Artists</h4>
-        <ul>
-          <li><a href="micah.html">Micah</a></li>
-          <li><a href="pagan.html">Pagan</a></li>
-          <li><a href="jimmy.html">Jimmy</a></li>
-          <li><a href="kason.html">Kason</a></li>
-          <li><a href="sarah.html">Sarah</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Services</h4>
-        <ul>
-          <li><a href="../index.html#services">Tattoos</a></li>
-          <li><a href="../index.html#services">Piercing</a></li>
-          <li><a href="../index.html#faq">Aftercare</a></li>
-          <li><a href="../index.html#book">Booking</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Info</h4>
-        <ul>
-          <li><a href="../index.html#about">About</a></li>
-          <li><a href="../index.html#faq">FAQ</a></li>
-          <li><a href="../index.html#studio">Studio</a></li>
-          <li><a href="../index.html#contact">Contact</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Explore</h4>
-        <ul>
-          <li><a href="../index.html#about">About</a></li>
-          <li><a href="../studio.html">Studio News</a></li>
-        </ul>
-      </div>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+        <div class="footer-content">
+            <div class="footer-brand">
+                <div class="footer-logo">
+                    <img src="../images/logo.jpg" alt="Valhalla Tattoo" class="footer-logo-img">
+                    <span class="footer-logo-text">VALHALLA TATTOO</span>
+                </div>
+                <p class="footer-tagline">Crafting Legends in Ink</p>
+            </div>
+            <div class="footer-info">
+                <h4>Contact Info</h4>
+                <address>
+                    <p>404 Mclemore Ave. Suite 4<br>Spring Hill, TN 37174</p>
+                    <p><a href="tel:931-451-5313">931-451-5313</a></p>
+                </address>
+            </div>
+            <div class="footer-hours">
+                <h4>Studio Hours</h4>
+                <p>Tuesday - Saturday<br>12:00 PM - 8:00 PM</p>
+                <p>Sunday & Monday<br>Closed</p>
+            </div>
+            <div class="footer-social">
+                <h4>Follow Us</h4>
+                <div class="footer-social-links">
+                    <a href="https://www.instagram.com/valhallatattoollc/" class="footer-social-link" aria-label="Follow Valhalla Tattoo on Instagram">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
+                        </svg>
+                    </a>
+                    <a href="https://www.facebook.com/Valhallatattoollc" class="footer-social-link" aria-label="Follow Valhalla Tattoo on Facebook">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2024 Valhalla Tattoo. All rights reserved.</p>
+            <p>Crafted with ⚡ in Spring Hill, TN</p>
+        </div>
     </div>
-    <div class="footer-bottom">
-      <a href="../index.html#book" class="btn-cta">Book</a>
-      <div class="social-icons">
-        <a href="https://www.instagram.com/thevalhallatattoo/" aria-label="Instagram"><span class="icon instagram-icon"></span></a>
-        <a href="https://www.facebook.com/Valhallatattoollc" aria-label="Facebook"><span class="icon facebook-icon"></span></a>
-        <a href="https://twitter.com/valhallatattoo" aria-label="Twitter"><span class="icon twitter-icon"></span></a>
-      </div>
-      <p>All rights reserved © 2025 Valhalla Tattoo</p>
-    </div>
-  </footer>
+</footer>
+
 
   <script type="module" src="../js/main.js"></script>
   <script type="module" src="../components/portfolio/artist-bio.js"></script>

--- a/portfolio/kason.html
+++ b/portfolio/kason.html
@@ -268,54 +268,51 @@
   </main>
 
   <!-- Footer -->
-  <footer class="site-footer">
-    <div class="footer-nav">
-      <div class="footer-col">
-        <h4>Artists</h4>
-        <ul>
-          <li><a href="micah.html">Micah</a></li>
-          <li><a href="pagan.html">Pagan</a></li>
-          <li><a href="jimmy.html">Jimmy</a></li>
-          <li><a href="kason.html">Kason</a></li>
-          <li><a href="sarah.html">Sarah</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Services</h4>
-        <ul>
-          <li><a href="../index.html#services">Tattoos</a></li>
-          <li><a href="../index.html#services">Piercing</a></li>
-          <li><a href="../index.html#faq">Aftercare</a></li>
-          <li><a href="../index.html#book">Booking</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Info</h4>
-        <ul>
-          <li><a href="../index.html#about">About</a></li>
-          <li><a href="../index.html#faq">FAQ</a></li>
-          <li><a href="../index.html#studio">Studio</a></li>
-          <li><a href="../index.html#contact">Contact</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Explore</h4>
-        <ul>
-          <li><a href="../index.html#about">About</a></li>
-          <li><a href="../studio.html">Studio News</a></li>
-        </ul>
-      </div>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+        <div class="footer-content">
+            <div class="footer-brand">
+                <div class="footer-logo">
+                    <img src="../images/logo.jpg" alt="Valhalla Tattoo" class="footer-logo-img">
+                    <span class="footer-logo-text">VALHALLA TATTOO</span>
+                </div>
+                <p class="footer-tagline">Crafting Legends in Ink</p>
+            </div>
+            <div class="footer-info">
+                <h4>Contact Info</h4>
+                <address>
+                    <p>404 Mclemore Ave. Suite 4<br>Spring Hill, TN 37174</p>
+                    <p><a href="tel:931-451-5313">931-451-5313</a></p>
+                </address>
+            </div>
+            <div class="footer-hours">
+                <h4>Studio Hours</h4>
+                <p>Tuesday - Saturday<br>12:00 PM - 8:00 PM</p>
+                <p>Sunday & Monday<br>Closed</p>
+            </div>
+            <div class="footer-social">
+                <h4>Follow Us</h4>
+                <div class="footer-social-links">
+                    <a href="https://www.instagram.com/valhallatattoollc/" class="footer-social-link" aria-label="Follow Valhalla Tattoo on Instagram">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
+                        </svg>
+                    </a>
+                    <a href="https://www.facebook.com/Valhallatattoollc" class="footer-social-link" aria-label="Follow Valhalla Tattoo on Facebook">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2024 Valhalla Tattoo. All rights reserved.</p>
+            <p>Crafted with ⚡ in Spring Hill, TN</p>
+        </div>
     </div>
-    <div class="footer-bottom">
-      <a href="../index.html#book" class="btn-cta">Book</a>
-      <div class="social-icons">
-        <a href="https://www.instagram.com/thevalhallatattoo/" aria-label="Instagram"><span class="icon instagram-icon"></span></a>
-        <a href="https://www.facebook.com/Valhallatattoollc" aria-label="Facebook"><span class="icon facebook-icon"></span></a>
-        <a href="https://twitter.com/valhallatattoo" aria-label="Twitter"><span class="icon twitter-icon"></span></a>
-      </div>
-      <p>All rights reserved © 2025 Valhalla Tattoo</p>
-    </div>
-  </footer>
+</footer>
+
 
   <script type="module" src="../js/main.js"></script>
   <script type="module" src="../components/portfolio/artist-bio.js"></script>

--- a/portfolio/micah.html
+++ b/portfolio/micah.html
@@ -285,55 +285,51 @@
   </main>
 
   <!-- Footer -->
-  <footer class="site-footer">
-    <div class="footer-nav">
-      <div class="footer-col">
-        <h4>Artists</h4>
-        <ul>
-          <li><a href="micah.html">Micah</a></li>
-          <li><a href="pagan.html">Pagan</a></li>
-          <li><a href="jimmy.html">Jimmy</a></li>
-          <li><a href="kason.html">Kason</a></li>
-          <li><a href="sarah.html">Sarah</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Services</h4>
-        <ul>
-          <li><a href="../index.html#services">Tattoos</a></li>
-          <li><a href="../index.html#services">Piercing</a></li>
-          <li><a href="../index.html#faq">Aftercare</a></li>
-          <li><a href="../index.html#book">Booking</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Info</h4>
-        <ul>
-          <li><a href="../index.html#about">About</a></li>
-          <li><a href="../index.html#faq">FAQ</a></li>
-          <li><a href="../index.html#studio">Studio</a></li>
-          <li><a href="../index.html#contact">Contact</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Explore</h4>
-        <ul>
-          <li><a href="../index.html#about">About</a></li>
-          <li><a href="../studio.html">Studio News</a></li>
-        </ul>
-      </div>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+        <div class="footer-content">
+            <div class="footer-brand">
+                <div class="footer-logo">
+                    <img src="../images/logo.jpg" alt="Valhalla Tattoo" class="footer-logo-img">
+                    <span class="footer-logo-text">VALHALLA TATTOO</span>
+                </div>
+                <p class="footer-tagline">Crafting Legends in Ink</p>
+            </div>
+            <div class="footer-info">
+                <h4>Contact Info</h4>
+                <address>
+                    <p>404 Mclemore Ave. Suite 4<br>Spring Hill, TN 37174</p>
+                    <p><a href="tel:931-451-5313">931-451-5313</a></p>
+                </address>
+            </div>
+            <div class="footer-hours">
+                <h4>Studio Hours</h4>
+                <p>Tuesday - Saturday<br>12:00 PM - 8:00 PM</p>
+                <p>Sunday & Monday<br>Closed</p>
+            </div>
+            <div class="footer-social">
+                <h4>Follow Us</h4>
+                <div class="footer-social-links">
+                    <a href="https://www.instagram.com/valhallatattoollc/" class="footer-social-link" aria-label="Follow Valhalla Tattoo on Instagram">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
+                        </svg>
+                    </a>
+                    <a href="https://www.facebook.com/Valhallatattoollc" class="footer-social-link" aria-label="Follow Valhalla Tattoo on Facebook">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2024 Valhalla Tattoo. All rights reserved.</p>
+            <p>Crafted with ⚡ in Spring Hill, TN</p>
+        </div>
     </div>
-    <div class="footer-bottom">
-      <a href="../index.html#book" class="btn-cta">Book</a>
-      <div class="social-icons">
-        <a href="https://www.instagram.com/thevalhallatattoo/" aria-label="Instagram"><span
-            class="icon instagram-icon"></span></a>
-        <a href="https://www.facebook.com/Valhallatattoollc" aria-label="Facebook"><span class="icon facebook-icon"></span></a>
-        <a href="https://twitter.com/valhallatattoo" aria-label="Twitter"><span class="icon twitter-icon"></span></a>
-      </div>
-      <p>All rights reserved © 2025 Valhalla Tattoo</p>
-    </div>
-  </footer>
+</footer>
+
 
   <script type="module" src="../js/main.js"></script>
   <script type="module" src="../components/portfolio/artist-bio.js"></script>

--- a/portfolio/pagan.html
+++ b/portfolio/pagan.html
@@ -268,54 +268,51 @@
   </main>
 
   <!-- Footer -->
-  <footer class="site-footer">
-    <div class="footer-nav">
-      <div class="footer-col">
-        <h4>Artists</h4>
-        <ul>
-          <li><a href="micah.html">Micah</a></li>
-          <li><a href="pagan.html">Pagan</a></li>
-          <li><a href="jimmy.html">Jimmy</a></li>
-          <li><a href="kason.html">Kason</a></li>
-          <li><a href="sarah.html">Sarah</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Services</h4>
-        <ul>
-          <li><a href="../index.html#services">Tattoos</a></li>
-          <li><a href="../index.html#services">Piercing</a></li>
-          <li><a href="../index.html#faq">Aftercare</a></li>
-          <li><a href="../index.html#book">Booking</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Info</h4>
-        <ul>
-          <li><a href="../index.html#about">About</a></li>
-          <li><a href="../index.html#faq">FAQ</a></li>
-          <li><a href="../index.html#studio">Studio</a></li>
-          <li><a href="../index.html#contact">Contact</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Explore</h4>
-        <ul>
-          <li><a href="../index.html#about">About</a></li>
-          <li><a href="../studio.html">Studio News</a></li>
-        </ul>
-      </div>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+        <div class="footer-content">
+            <div class="footer-brand">
+                <div class="footer-logo">
+                    <img src="../images/logo.jpg" alt="Valhalla Tattoo" class="footer-logo-img">
+                    <span class="footer-logo-text">VALHALLA TATTOO</span>
+                </div>
+                <p class="footer-tagline">Crafting Legends in Ink</p>
+            </div>
+            <div class="footer-info">
+                <h4>Contact Info</h4>
+                <address>
+                    <p>404 Mclemore Ave. Suite 4<br>Spring Hill, TN 37174</p>
+                    <p><a href="tel:931-451-5313">931-451-5313</a></p>
+                </address>
+            </div>
+            <div class="footer-hours">
+                <h4>Studio Hours</h4>
+                <p>Tuesday - Saturday<br>12:00 PM - 8:00 PM</p>
+                <p>Sunday & Monday<br>Closed</p>
+            </div>
+            <div class="footer-social">
+                <h4>Follow Us</h4>
+                <div class="footer-social-links">
+                    <a href="https://www.instagram.com/valhallatattoollc/" class="footer-social-link" aria-label="Follow Valhalla Tattoo on Instagram">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
+                        </svg>
+                    </a>
+                    <a href="https://www.facebook.com/Valhallatattoollc" class="footer-social-link" aria-label="Follow Valhalla Tattoo on Facebook">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2024 Valhalla Tattoo. All rights reserved.</p>
+            <p>Crafted with ⚡ in Spring Hill, TN</p>
+        </div>
     </div>
-    <div class="footer-bottom">
-      <a href="../index.html#book" class="btn-cta">Book</a>
-      <div class="social-icons">
-        <a href="https://www.instagram.com/thevalhallatattoo/" aria-label="Instagram"><span class="icon instagram-icon"></span></a>
-        <a href="https://www.facebook.com/Valhallatattoollc" aria-label="Facebook"><span class="icon facebook-icon"></span></a>
-        <a href="https://twitter.com/valhallatattoo" aria-label="Twitter"><span class="icon twitter-icon"></span></a>
-      </div>
-      <p>All rights reserved © 2025 Valhalla Tattoo</p>
-    </div>
-  </footer>
+</footer>
+
 
   <script type="module" src="../js/main.js"></script>
   <script type="module" src="../components/portfolio/artist-bio.js"></script>

--- a/portfolio/sarah.html
+++ b/portfolio/sarah.html
@@ -268,54 +268,51 @@
   </main>
 
   <!-- Footer -->
-  <footer class="site-footer">
-    <div class="footer-nav">
-      <div class="footer-col">
-        <h4>Artists</h4>
-        <ul>
-          <li><a href="micah.html">Micah</a></li>
-          <li><a href="pagan.html">Pagan</a></li>
-          <li><a href="jimmy.html">Jimmy</a></li>
-          <li><a href="kason.html">Kason</a></li>
-          <li><a href="sarah.html">Sarah</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Services</h4>
-        <ul>
-          <li><a href="../index.html#services">Tattoos</a></li>
-          <li><a href="../index.html#services">Piercing</a></li>
-          <li><a href="../index.html#faq">Aftercare</a></li>
-          <li><a href="../index.html#book">Booking</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Info</h4>
-        <ul>
-          <li><a href="../index.html#about">About</a></li>
-          <li><a href="../index.html#faq">FAQ</a></li>
-          <li><a href="../index.html#studio">Studio</a></li>
-          <li><a href="../index.html#contact">Contact</a></li>
-        </ul>
-      </div>
-      <div class="footer-col">
-        <h4>Explore</h4>
-        <ul>
-          <li><a href="../index.html#about">About</a></li>
-          <li><a href="../studio.html">Studio News</a></li>
-        </ul>
-      </div>
+  <footer class="footer" role="contentinfo">
+    <div class="container">
+        <div class="footer-content">
+            <div class="footer-brand">
+                <div class="footer-logo">
+                    <img src="../images/logo.jpg" alt="Valhalla Tattoo" class="footer-logo-img">
+                    <span class="footer-logo-text">VALHALLA TATTOO</span>
+                </div>
+                <p class="footer-tagline">Crafting Legends in Ink</p>
+            </div>
+            <div class="footer-info">
+                <h4>Contact Info</h4>
+                <address>
+                    <p>404 Mclemore Ave. Suite 4<br>Spring Hill, TN 37174</p>
+                    <p><a href="tel:931-451-5313">931-451-5313</a></p>
+                </address>
+            </div>
+            <div class="footer-hours">
+                <h4>Studio Hours</h4>
+                <p>Tuesday - Saturday<br>12:00 PM - 8:00 PM</p>
+                <p>Sunday & Monday<br>Closed</p>
+            </div>
+            <div class="footer-social">
+                <h4>Follow Us</h4>
+                <div class="footer-social-links">
+                    <a href="https://www.instagram.com/valhallatattoollc/" class="footer-social-link" aria-label="Follow Valhalla Tattoo on Instagram">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
+                        </svg>
+                    </a>
+                    <a href="https://www.facebook.com/Valhallatattoollc" class="footer-social-link" aria-label="Follow Valhalla Tattoo on Facebook">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2024 Valhalla Tattoo. All rights reserved.</p>
+            <p>Crafted with ⚡ in Spring Hill, TN</p>
+        </div>
     </div>
-    <div class="footer-bottom">
-      <a href="../index.html#book" class="btn-cta">Book</a>
-      <div class="social-icons">
-        <a href="https://www.instagram.com/thevalhallatattoo/" aria-label="Instagram"><span class="icon instagram-icon"></span></a>
-        <a href="https://www.facebook.com/Valhallatattoollc" aria-label="Facebook"><span class="icon facebook-icon"></span></a>
-        <a href="https://twitter.com/valhallatattoo" aria-label="Twitter"><span class="icon twitter-icon"></span></a>
-      </div>
-      <p>All rights reserved © 2025 Valhalla Tattoo</p>
-    </div>
-  </footer>
+</footer>
+
 
   <script type="module" src="../js/main.js"></script>
   <script type="module" src="../components/portfolio/artist-bio.js"></script>


### PR DESCRIPTION
## Summary
- replace legacy `site-footer` blocks in portfolio pages with modern footer layout from `thank-you.html`
- standardize studio contact info, hours, and social links to match homepage

## Testing
- `npm test` *(fails: Cannot find module 'scripts/test-runner.js')*
- `npm run lint` *(fails: Cannot find module 'scripts/lint-check.js')*

------
https://chatgpt.com/codex/tasks/task_e_689e12d5ac14832f93050dfab9daf6b1