### PR TITLE
refactor: unify portfolio styles

### DIFF
--- a/portfolio/heather.html
+++ b/portfolio/heather.html
@@ -7,10 +7,10 @@
   <meta name="keywords" content="Heather tattoo portfolio, tattoo artist, Valhalla Tattoo, Spring Hill TN">
   <meta name="author" content="Valhalla Tattoo">
   <title>Heather's Portfolio | Valhalla Tattoo</title>
-  <link rel="stylesheet" href="../css/reset.css">
-  <link rel="stylesheet" href="../css/styles.css">
-  <link rel="stylesheet" href="../css/artists.css">
-  <link rel="stylesheet" href="../css/portfolio.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/css/main.css">
   <link rel="stylesheet" href="../assets/css/portfolio-pages.css">
 </head>
 <body>

--- a/portfolio/kason.html
+++ b/portfolio/kason.html
@@ -7,10 +7,10 @@
   <meta name="keywords" content="Kason tattoo portfolio, tattoo artist, Valhalla Tattoo, Spring Hill TN">
   <meta name="author" content="Valhalla Tattoo">
   <title>Kason's Portfolio | Valhalla Tattoo</title>
-  <link rel="stylesheet" href="../css/reset.css">
-  <link rel="stylesheet" href="../css/styles.css">
-  <link rel="stylesheet" href="../css/artists.css">
-  <link rel="stylesheet" href="../css/portfolio.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/css/main.css">
   <link rel="stylesheet" href="../assets/css/portfolio-pages.css">
 </head>
 <body>

--- a/portfolio/micah.html
+++ b/portfolio/micah.html
@@ -8,10 +8,10 @@
   <meta name="keywords" content="Micah tattoo portfolio, tattoo artist, Valhalla Tattoo, Spring Hill TN">
   <meta name="author" content="Valhalla Tattoo">
   <title>Micah's Portfolio | Valhalla Tattoo</title>
-  <link rel="stylesheet" href="../css/reset.css">
-  <link rel="stylesheet" href="../css/styles.css">
-  <link rel="stylesheet" href="../css/artists.css">
-  <link rel="stylesheet" href="../css/portfolio.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/css/main.css">
   <link rel="stylesheet" href="../assets/css/portfolio-pages.css">
 </head>
 

--- a/portfolio/pagan.html
+++ b/portfolio/pagan.html
@@ -7,10 +7,10 @@
   <meta name="keywords" content="Pagan tattoo portfolio, tattoo artist, Valhalla Tattoo, Spring Hill TN">
   <meta name="author" content="Valhalla Tattoo">
   <title>Pagan's Portfolio | Valhalla Tattoo</title>
-  <link rel="stylesheet" href="../css/reset.css">
-  <link rel="stylesheet" href="../css/styles.css">
-  <link rel="stylesheet" href="../css/artists.css">
-  <link rel="stylesheet" href="../css/portfolio.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/css/main.css">
   <link rel="stylesheet" href="../assets/css/portfolio-pages.css">
 </head>
 <body>

--- a/portfolio/sarah.html
+++ b/portfolio/sarah.html
@@ -7,10 +7,10 @@
   <meta name="keywords" content="Sarah tattoo portfolio, tattoo artist, Valhalla Tattoo, Spring Hill TN">
   <meta name="author" content="Valhalla Tattoo">
   <title>Sarah's Portfolio | Valhalla Tattoo</title>
-  <link rel="stylesheet" href="../css/reset.css">
-  <link rel="stylesheet" href="../css/styles.css">
-  <link rel="stylesheet" href="../css/artists.css">
-  <link rel="stylesheet" href="../css/portfolio.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/css/main.css">
   <link rel="stylesheet" href="../assets/css/portfolio-pages.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- replace outdated CSS references in portfolio pages with main styles
- add Google Fonts and portfolio page CSS for consistent typography

## Testing
- ⚠️ `npm test` *(fails: Cannot find module 'scripts/test-runner.js')*
- ⚠️ `npm run lint` *(fails: Cannot find module 'scripts/lint-check.js')*

------
https://chatgpt.com/codex/tasks/task_e_689e12c4389c832fb9dd44069826e39e