### PR TITLE
Fix JS minification to preserve URLs

### DIFF
--- a/scripts/build-optimize.js
+++ b/scripts/build-optimize.js
@@ -20,7 +20,8 @@ function minifyCSS(cssContent) {
 function minifyJS(jsContent) {
   return jsContent
     .replace(/\/\*[\s\S]*?\*\//g, '') // Remove block comments
-    .replace(/\/\/.*$/gm, '') // Remove line comments
+    // Remove line comments but preserve URLs like http:// or https://
+    .replace(/(?<!:)\/\/.*$/gm, '')
     .replace(/\s+/g, ' ') // Collapse whitespace
     .replace(/;\s*}/g, '}') // Clean up
     .trim();


### PR DESCRIPTION
## Summary
- Avoid stripping URL strings when removing line comments during JS minification
- Prevents `https://` links from breaking and causing runtime syntax errors

## Testing
- `node scripts/build-optimize.js`
- `npm test` *(fails: Cannot find module 'scripts/test-runner.js')*
- `npm run lint` *(fails: Cannot find module 'scripts/lint-check.js')*

------
https://chatgpt.com/codex/tasks/task_e_689e2f38e724832f8d1554c508369432