### PR TITLE
Refactor contact form file list listener

### DIFF
--- a/components/forms/contact-form.js
+++ b/components/forms/contact-form.js
@@ -12,12 +12,14 @@ class ContactForm {
     this.fields = {};
     this.errors = {};
     this.isSubmitting = false;
-    
+    this.fileList = null;
+
     this.init();
   }
 
   init() {
     this.setupFields();
+    this.setupFileList();
     this.setupEventListeners();
     this.setupHoneypot();
   }
@@ -37,6 +39,18 @@ class ContactForm {
       referenceImages: this.form.querySelector('#contact-reference'),
       honeypot: this.form.querySelector('#contact-honeypot')
     };
+  }
+
+  setupFileList() {
+    this.fileList = this.form.querySelector('.file-upload-list');
+    if (this.fileList) {
+      this.fileList.addEventListener('click', (e) => {
+        if (e.target.closest('.file-remove')) {
+          const index = parseInt(e.target.closest('.file-remove').dataset.index);
+          this.removeFile(index);
+        }
+      });
+    }
   }
 
   setupEventListeners() {
@@ -435,11 +449,10 @@ class ContactForm {
   }
 
   updateFileUploadDisplay(files) {
-    const fileList = this.form.querySelector('.file-upload-list');
-    if (!fileList) return;
+    if (!this.fileList) return;
 
-    fileList.innerHTML = '';
-    
+    this.fileList.innerHTML = '';
+
     Array.from(files).forEach((file, index) => {
       const fileItem = document.createElement('div');
       fileItem.className = 'file-upload-item';
@@ -452,15 +465,7 @@ class ContactForm {
           </svg>
         </button>
       `;
-      fileList.appendChild(fileItem);
-    });
-
-    // Add remove file functionality
-    fileList.addEventListener('click', (e) => {
-      if (e.target.closest('.file-remove')) {
-        const index = parseInt(e.target.closest('.file-remove').dataset.index);
-        this.removeFile(index);
-      }
+      this.fileList.appendChild(fileItem);
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure contact form's file list remove handler initializes only once
- streamline file upload display updates to just render DOM elements

## Testing
- `npm test` (fails: Cannot find module '/workspace/ValhallaLLC/scripts/test-runner.js')
- `node /tmp/filelist-test.js`


------
https://chatgpt.com/codex/tasks/task_e_689e8a5a4f48832f9f2aeb8fc592bc5e