### PR TITLE
feat: externalize analytics measurement id

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,16 +80,31 @@
     }
     </script>
     
-    <!-- Google Analytics - Placeholder ID (to be replaced with actual ID later) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-PLACEHOLDER"></script>
+    <!-- Google Analytics -->
     <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'G-PLACEHOLDER', {
-            anonymize_ip: true,
-            cookie_flags: 'SameSite=None;Secure'
-        });
+        (function() {
+            const GA_MEASUREMENT_ID = 'GA_MEASUREMENT_ID';
+
+            if (GA_MEASUREMENT_ID && GA_MEASUREMENT_ID !== 'GA_MEASUREMENT_ID') {
+                const gtagScript = document.createElement('script');
+                gtagScript.async = true;
+                gtagScript.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
+                document.head.appendChild(gtagScript);
+
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                window.gtag = gtag;
+
+                gtag('js', new Date());
+                gtag('config', GA_MEASUREMENT_ID, {
+                    anonymize_ip: true,
+                    cookie_flags: 'SameSite=None;Secure'
+                });
+            } else {
+                window.gtag = function() {};
+                console.warn('Google Analytics disabled: GA measurement ID not provided.');
+            }
+        })();
     </script>
 </head>
 <body>

--- a/js/config/analytics.js
+++ b/js/config/analytics.js
@@ -5,8 +5,8 @@
 
 export const analyticsConfig = {
     // Google Analytics 4 Measurement ID
-    // Replace with actual measurement ID from Google Analytics
-    measurementId: 'G-PLACEHOLDER',
+    // Replaced at build time with actual ID
+    measurementId: 'GA_MEASUREMENT_ID',
     
     // Debug mode (set to false in production)
     debugMode: false,
@@ -90,7 +90,6 @@ export const analyticsConfig = {
 // Environment-specific overrides
 if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
     analyticsConfig.debugMode = true;
-    analyticsConfig.measurementId = 'G-PLACEHOLDER-DEV'; // Use test measurement ID for development
 }
 
 export default analyticsConfig;

--- a/js/modules/analytics.js
+++ b/js/modules/analytics.js
@@ -35,24 +35,30 @@ class AnalyticsManager {
   
   async initGoogleAnalytics() {
     const { trackingId } = this.config.analytics.googleAnalytics;
-    
+
+    if (!trackingId || trackingId === 'GA_MEASUREMENT_ID') {
+      window.gtag = function() {};
+      console.warn('Google Analytics disabled: tracking ID not provided.');
+      return;
+    }
+
     // Load Google Analytics
     const script = document.createElement('script');
     script.async = true;
     script.src = `https://www.googletagmanager.com/gtag/js?id=${trackingId}`;
     document.head.appendChild(script);
-    
+
     // Initialize gtag
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     window.gtag = gtag;
-    
+
     gtag('js', new Date());
     gtag('config', trackingId, {
       anonymize_ip: true,
       cookie_flags: 'SameSite=None;Secure'
     });
-    
+
     console.log('📊 Google Analytics initialized');
   }
   

--- a/scripts/build-env.js
+++ b/scripts/build-env.js
@@ -53,6 +53,26 @@ fs.writeFileSync(envConfigPath, envConfigContent);
 console.log('✅ Environment configuration built successfully');
 console.log('📍 Configuration written to:', envConfigPath);
 
+// Replace Google Analytics measurement ID in source files
+const GA_PLACEHOLDER = 'GA_MEASUREMENT_ID';
+const gaId = envConfig.GA_TRACKING_ID;
+
+function replaceAnalyticsId(filePath) {
+  if (!fs.existsSync(filePath)) return;
+  const content = fs.readFileSync(filePath, 'utf8');
+  let updated = content;
+  updated = updated.replace(/'GA_MEASUREMENT_ID'/g, gaId ? `'${gaId}'` : `'GA_MEASUREMENT_ID'`);
+  updated = updated.replace(/"GA_MEASUREMENT_ID"/g, gaId ? `"${gaId}"` : '"GA_MEASUREMENT_ID"');
+  fs.writeFileSync(filePath, updated);
+  console.log(`🔄 Updated GA ID in ${path.relative(path.join(__dirname, '..'), filePath)}`);
+}
+
+[
+  path.join(__dirname, '../index.html'),
+  path.join(__dirname, '../js/config/analytics.js'),
+  path.join(__dirname, '../js/modules/analytics.js')
+].forEach(replaceAnalyticsId);
+
 // Log feature status
 console.log('\n🎯 Feature Status:');
 console.log(`   Instagram Integration: ${envConfig.INSTAGRAM_ACCESS_TOKEN ? '✅ Enabled' : '❌ Disabled'}`);


### PR DESCRIPTION
## Summary
- load Google Analytics with build-time measurement ID and no-op fallback when missing
- expose GA ID in configuration and analytics modules for environment replacement
- inject measurement ID into source files during build from `GA_TRACKING_ID`

## Testing
- `npm test` *(fails: Cannot find module 'scripts/test-runner.js')*
- `npm run lint` *(fails: Cannot find module 'scripts/lint-check.js')*
- `GA_TRACKING_ID=G-TEST1234567 npm run build:env`


------
https://chatgpt.com/codex/tasks/task_e_689e8a5d35b8832f883c7dea97e864b7