### PR TITLE
Use production domain in SEO meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,14 +8,14 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://valhallatattoollc.netlify.app/">
+    <meta property="og:url" content="https://valhallatattoo.com/">
     <meta property="og:title" content="Valhalla Tattoo - Professional Tattoo Studio in Spring Hill, TN">
     <meta property="og:description" content="Premium tattoo artistry in Spring Hill, Tennessee. Expert artists specializing in traditional, realism, and custom tattoo designs.">
     <meta property="og:image" content="/images/og-image.jpg">
     
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://valhallatattoollc.netlify.app/">
+    <meta property="twitter:url" content="https://valhallatattoo.com/">
     <meta property="twitter:title" content="Valhalla Tattoo - Professional Tattoo Studio in Spring Hill, TN">
     <meta property="twitter:description" content="Premium tattoo artistry in Spring Hill, Tennessee. Expert artists specializing in traditional, realism, and custom tattoo designs.">
     <meta property="twitter:image" content="/images/og-image.jpg">
@@ -23,7 +23,7 @@
     <title>Valhalla Tattoo - Professional Tattoo Studio in Spring Hill, TN</title>
     
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://valhallatattoollc.netlify.app/">
+    <link rel="canonical" href="https://valhallatattoo.com/">
     
     <!-- Additional SEO Meta Tags -->
     <meta name="author" content="Valhalla Tattoo">


### PR DESCRIPTION
## Summary
- replace Netlify subdomain with `https://valhallatattoo.com` in Open Graph, Twitter, and canonical tags
- ensure other pages and configs reference the production domain

## Testing
- `npm test` *(fails: Cannot find module scripts/test-runner.js)*
- `npm run lint` *(fails: Cannot find module scripts/lint-check.js)*
- `node` *(verified canonical, OG, and Twitter URLs all point to https://valhallatattoo.com)*

------
https://chatgpt.com/codex/tasks/task_e_689e8a603698832f95bd7212da859baf