### PR TITLE
fix: resolve module import errors

### DIFF
--- a/js/data/artists.js
+++ b/js/data/artists.js
@@ -1004,3 +1004,6 @@ class PortfolioCache {
 }
 
 export const portfolioCache = new PortfolioCache();
+
+// Provide default export for convenience when importing the entire dataset
+export default artistsData;

--- a/js/modules/sitemap.js
+++ b/js/modules/sitemap.js
@@ -3,7 +3,8 @@
  * Generates dynamic sitemap for SEO optimization
  */
 
-class SitemapGenerator {
+// Export the generator as the default class to ensure proper module parsing
+export default class SitemapGenerator {
     constructor() {
         this.baseUrl = 'https://valhallatattoo.com';
         this.pages = [];
@@ -153,6 +154,3 @@ class SitemapGenerator {
         return this.generateXML();
     }
 }
-
-// Export for use in other modules
-export default SitemapGenerator;


### PR DESCRIPTION
## Summary
- convert sitemap generator into a default-exported class to avoid import syntax issues
- export artist data as a default dataset for easier module consumption

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module '/workspace/ValhallaLLC/scripts/lint-check.js')*

------
https://chatgpt.com/codex/tasks/task_e_689e923ebc00832fa5bb20f59f083f8f