### PR TITLE
Fix portfolio artist slug detection

### DIFF
--- a/js/portfolio-page.js
+++ b/js/portfolio-page.js
@@ -669,9 +669,20 @@ window.PortfolioPageManager = {
   // Initialize the portfolio page
   init: function() {
     // Get artist slug from URL
-    const urlPath = window.location.pathname;
-    const artistSlug = urlPath.split('/').pop().replace('.html', '');
-    
+    const currentUrl = new URL(window.location.href);
+    const pathSegments = currentUrl.pathname.split('/').filter(Boolean);
+    let artistSlug = pathSegments.pop() || '';
+
+    if (!artistSlug && pathSegments.length) {
+      artistSlug = pathSegments.pop() || '';
+    }
+
+    if (!artistSlug && currentUrl.searchParams.has('artist')) {
+      artistSlug = currentUrl.searchParams.get('artist') || '';
+    }
+
+    artistSlug = artistSlug.replace(/\.html$/i, '').toLowerCase();
+
     this.currentArtist = window.ValhallaTattooArtists[artistSlug];
     
     if (this.currentArtist) {


### PR DESCRIPTION
## Summary
- normalize artist slug parsing on portfolio pages to handle trailing slashes and query strings
- fall back to query parameters when the slug cannot be derived from the path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c84369df6c832f9099857a49b73da4