### PR TITLE
Fix portfolio gallery grid and image loading

### DIFF
--- a/assets/css/portfolio-pages.css
+++ b/assets/css/portfolio-pages.css
@@ -148,6 +148,12 @@
   margin-bottom: 3rem;
 }
 
+.portfolio-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2rem;
+}
+
 .portfolio-item {
   position: relative;
   border-radius: 12px;
@@ -347,7 +353,8 @@
     gap: 1.5rem;
   }
   
-  .portfolio-gallery {
+  .portfolio-gallery,
+  .portfolio-gallery-grid {
     grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     gap: 1.5rem;
   }
@@ -377,7 +384,8 @@
     font-size: 2rem;
   }
   
-  .portfolio-gallery {
+  .portfolio-gallery,
+  .portfolio-gallery-grid {
     grid-template-columns: 1fr;
   }
   


### PR DESCRIPTION
## Summary
- enable the gallery component's lazy loading logic so thumbnails swap from placeholders to actual portfolio images
- add CSS grid rules for the generated `.portfolio-gallery-grid` wrapper so portfolio pages render images in a responsive grid, including responsive tweaks

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c98ffd37fc832f95d6222eb8e6449e